### PR TITLE
Make 'include fastcgi_params' optional within location

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -35,6 +35,8 @@
 #   [*fastcgi*]              - location of fastcgi (host:port)
 #   [*fastcgi_param*]        - Set additional custom fastcgi_params
 #   [*fastcgi_params*]       - optional alternative fastcgi_params file to use
+#   [*fastcgi_params_include*] - choose whether in location the 'include'
+#     parameter should be added or not
 #   [*fastcgi_script*]       - optional SCRIPT_FILE parameter
 #   [*fastcgi_split_path*]   - Allows settings of fastcgi_split_path_info so
 #     that you can split the script_name and path_info via regex
@@ -149,6 +151,7 @@ define nginx::resource::location (
   $fastcgi              = undef,
   $fastcgi_param        = undef,
   $fastcgi_params       = "${nginx::config::conf_dir}/fastcgi_params",
+  $fastcgi_params_include = true,
   $fastcgi_script       = undef,
   $fastcgi_split_path   = undef,
   $uwsgi                = undef,

--- a/templates/vhost/locations/fastcgi.erb
+++ b/templates/vhost/locations/fastcgi.erb
@@ -1,7 +1,9 @@
 <% if defined? @www_root -%>
     root          <%= @www_root %>;
 <% end -%>
+<% if @fastcgi_params_include -%>
     include       <%= @fastcgi_params %>;
+<% end -%>
 <% if @try_files -%>
     try_files    <% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>


### PR DESCRIPTION
Allow to not append to the configs' file the 'include' parameter,
when using fastcgi.
